### PR TITLE
Tests improv

### DIFF
--- a/lib/includes/gnutls/crypto.h
+++ b/lib/includes/gnutls/crypto.h
@@ -321,7 +321,7 @@ typedef int (*gnutls_pk_pubkey_export_dh_raw_func)(void *ctx, const void *y);
 typedef int (*gnutls_pk_privkey_import_ecdh_raw_func)(void *ctx, int curve, const void *x, const void *y, const void *k);
 typedef int (*gnutls_pk_pubkey_import_ecdh_raw_func)(void *ctx, int curve, const void *x, const void *y);
 typedef int (*gnutls_pk_privkey_export_ecdh_raw_func)(void *ctx, const void *x, const void *y, const void *k);
-typedef int (*gnutls_pk_pubkey_export_ecdh_raw_func)(void *ctx, const void *x, const void *y);
+typedef int (*gnutls_pk_pubkey_export_ecdh_raw_func)(void *ctx, const void *x, const void *y, gnutls_ecc_curve_t *curve);
 typedef void (*gnutls_pk_deinit_func)(void *ctx);
 typedef int (*gnutls_pk_copy_func)(void **dst, void *src, gnutls_pk_algorithm_t algo);
 

--- a/lib/pubkey.c
+++ b/lib/pubkey.c
@@ -99,16 +99,24 @@ unsigned pubkey_to_bits(const gnutls_pk_params_st *params)
  **/
 int gnutls_pubkey_get_pk_algorithm(gnutls_pubkey_t key, unsigned int *bits)
 {
+    int result;
+
 	if (bits) {
 		const gnutls_crypto_pk_st *cc;
 		cc = _gnutls_get_crypto_pk(key->pk_algorithm);
 		if (cc != NULL && cc->get_bits != NULL) {
-			cc->get_bits(key->pk_ctx, bits);
+			result = cc->get_bits(key->pk_ctx, bits);
+            if (result < 0 && result != GNUTLS_E_ALGO_NOT_SUPPORTED) {
+                gnutls_assert();
+                return result;
+            } else if (result == 0) {
+                return key->params.algo;
+            }
 		}
-		else {
-			*bits = key->bits;
-		}
+
+        *bits = key->bits;
 	}
+
 
 	return key->params.algo;
 }
@@ -1485,6 +1493,17 @@ int gnutls_pubkey_export_ecc_raw2(gnutls_pubkey_t key,
 	if (curve)
 		*curve = key->params.curve;
 
+	const gnutls_crypto_pk_st *cc = _gnutls_get_crypto_pk(key->params.algo);
+	if (cc != NULL && cc->pubkey_export_ecdh_raw_backend != NULL) {
+		ret = cc->pubkey_export_ecdh_raw_backend(key->pk_ctx, x, y, curve);
+		if (ret < 0 && ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
+			gnutls_assert();
+			return ret;
+		} else if (ret == 0) {
+			return 0;
+		}
+	}
+
 	if (key->params.algo == GNUTLS_PK_EDDSA_ED25519 ||
 	    key->params.algo == GNUTLS_PK_EDDSA_ED448 ||
 	    key->params.algo == GNUTLS_PK_ECDH_X25519 ||
@@ -1499,19 +1518,8 @@ int gnutls_pubkey_export_ecc_raw2(gnutls_pubkey_t key,
 			y->data = NULL;
 			y->size = 0;
 		}
-		return 0;
-	}
 
-	/* ECDSA */
-	const gnutls_crypto_pk_st *cc = _gnutls_get_crypto_pk(GNUTLS_PK_ECDSA);
-	if (cc != NULL && cc->pubkey_export_ecdh_raw_backend != NULL) {
-		ret = cc->pubkey_export_ecdh_raw_backend(key->pk_ctx, x, y);
-		if (ret < 0 && ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
-			gnutls_assert();
-			return ret;
-		} else if (ret == 0) {
-			return 0;
-		}
+		return 0;
 	}
 
 	/* X */

--- a/tests/x509sign-verify-common.h
+++ b/tests/x509sign-verify-common.h
@@ -22,6 +22,18 @@ const gnutls_datum_t sha256_data = {
 	32
 };
 
+#ifdef GNUTLS_WOLFSSL
+/* sha384 hash of "hello" string */
+const gnutls_datum_t sha384_data = {
+	(void *)"\x59\xe1\x74\x87\x77\x44\x8c\x69\xde\x6b"
+		"\x80\x0d\x7a\x33\xbb\xfb\x9f\xf1\xb4\x63"
+		"\xe4\x43\x54\xc3\x55\x3b\xcd\xb9\xc6\x66"
+		"\xfa\x90\x12\x5a\x3c\x79\xf9\x03\x97\xbd"
+		"\xf5\xf6\xa1\x3d\xe8\x28\x68\x4f",
+	48
+};
+#endif
+
 /* gost r 34.11-94 hash of "hello" string */
 const gnutls_datum_t gostr94_data = {
 	(void *)"\x92\xea\x6d\xdb\xaf\x40\x02\x0d\xf3\x65"
@@ -113,6 +125,10 @@ static void test_sig(gnutls_pk_algorithm_t pk, unsigned hash, unsigned bits)
 		hash_data = &streebog256_data;
 	else if (hash == GNUTLS_DIG_STREEBOG_512)
 		hash_data = &streebog512_data;
+#ifdef GNUTLS_WOLFSSL
+	else if (hash == GNUTLS_DIG_SHA384)
+		hash_data = &sha384_data;
+#endif
 	else
 		abort();
 

--- a/tests/x509sign-verify-rsa.c
+++ b/tests/x509sign-verify-rsa.c
@@ -65,8 +65,13 @@ void doit(void)
 	}
 
 	test_sig(GNUTLS_PK_RSA, GNUTLS_DIG_SHA1, rsa_size1);
+#ifndef GNUTLS_WOLFSSL
 	test_sig(GNUTLS_PK_RSA, GNUTLS_DIG_SHA256, rsa_size2);
 	test_sig(GNUTLS_PK_RSA_PSS, GNUTLS_DIG_SHA256, rsa_size2);
+#else
+	test_sig(GNUTLS_PK_RSA, GNUTLS_DIG_SHA384, rsa_size2);
+	test_sig(GNUTLS_PK_RSA_PSS, GNUTLS_DIG_SHA384, rsa_size2);
+#endif
 
 	gnutls_global_deinit();
 }


### PR DESCRIPTION
Minor edits to fix these three core PK tests that regressed after the recent changes:
- privkey-derive;
- pubkey-import-export;
- x509-sign-verify-rsa;

