### PR TITLE
CRQ and PK Fixes

### DIFF
--- a/lib/includes/gnutls/crypto.h
+++ b/lib/includes/gnutls/crypto.h
@@ -266,7 +266,7 @@ typedef int (*gnutls_pk_get_spki_func)(void *ctx, void *spki);
 typedef int (*gnutls_pk_set_spki_func)(void *ctx, void *spki);
 typedef int (*gnutls_pk_generate_func)(void **ctx, const void *privkey,
                                           gnutls_pk_algorithm_t algo,
-                                          unsigned int bits, const void* p, const void* g, const void* q);
+                                          unsigned int bits, const void* p, const void* g, const void* q, gnutls_ecc_curve_t *curve);
 
 typedef int (*gnutls_pk_import_pubkey_func)(void **ctx,
 					    gnutls_pk_algorithm_t *algo,

--- a/lib/pubkey.c
+++ b/lib/pubkey.c
@@ -301,10 +301,12 @@ int gnutls_pubkey_import_x509(gnutls_pubkey_t key, gnutls_x509_crt_t crt,
 		return ret;
 	}
 
-	ret = _gnutls_pubkey_import_x509_provider(key, &crt->der, flags);
-	if (ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
-		return ret;
-	}
+    if (crt->der.size > 0) {
+        ret = _gnutls_pubkey_import_x509_provider(key, &crt->der, flags);
+        if (ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
+            return ret;
+        }
+    }
 
 	gnutls_pk_params_release(&key->params);
 	/* params initialized in _gnutls_x509_crt_get_mpis */

--- a/lib/pubkey.c
+++ b/lib/pubkey.c
@@ -296,10 +296,12 @@ int gnutls_pubkey_import_x509(gnutls_pubkey_t key, gnutls_x509_crt_t crt,
 	if (ret < 0)
 		key->key_usage = 0;
 
-	ret = _gnutls_pubkey_import_spki_provider(key, &crt->raw_spki);
-	if (ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
-		return ret;
-	}
+    if (crt->raw_spki.size > 0) {
+        ret = _gnutls_pubkey_import_spki_provider(key, &crt->raw_spki);
+        if (ret != GNUTLS_E_ALGO_NOT_SUPPORTED) {
+            return ret;
+        }
+    }
 
     if (crt->der.size > 0) {
         ret = _gnutls_pubkey_import_x509_provider(key, &crt->der, flags);

--- a/lib/pubkey.c
+++ b/lib/pubkey.c
@@ -342,9 +342,35 @@ int gnutls_pubkey_import_x509_crq(gnutls_pubkey_t key, gnutls_x509_crq_t crq,
 				  unsigned int flags)
 {
 	int ret;
+    int result;
 
 	gnutls_pk_params_release(&key->params);
 	/* params initialized in _gnutls_x509_crq_get_mpis */
+
+	const gnutls_crypto_pk_st *cc;
+
+	cc = _gnutls_get_crypto_pk(crq->pk_algorithm);
+	if (cc != NULL && cc->export_pubkey_backend != NULL) {
+		gnutls_datum_t datum = {
+			.data = NULL,
+			.size = 0
+		};
+
+        /* does export of the public key from the crq, and imports it back to the
+         * key struct. */
+		result = cc->export_pubkey_backend(&key->pk_ctx, crq->pk_ctx,
+						   &datum, 0);
+		if (result < 0 && result != GNUTLS_E_ALGO_NOT_SUPPORTED) {
+			gnutls_assert();
+			return result;
+		} else if (result == 0) {
+			if (result != 0) {
+				gnutls_assert();
+				return result;
+			}
+			return 0;
+		}
+	}
 
 	key->params.algo = gnutls_x509_crq_get_pk_algorithm(crq, &key->bits);
 

--- a/lib/x509/crq.c
+++ b/lib/x509/crq.c
@@ -654,14 +654,14 @@ int gnutls_x509_crq_set_key(gnutls_x509_crq_t crq, gnutls_x509_privkey_t key)
 			return result;
 		} else if (result == 0) {
 			crq->pk_algorithm = key->pk_algorithm;
-                        result = _gnutls_x509_encode_with_PKI_params(crq->crq,
-                                "certificationRequestInfo.subjectPKInfo",
-				&key->params, &datum);
-                        gnutls_free(datum.data);
-                        if (result != 0) {
-                                gnutls_assert();
-                                return result;
-                        }
+			result = _gnutls_x509_encode_with_PKI_params(crq->crq,
+					"certificationRequestInfo.subjectPKInfo",
+					&key->params, &datum);
+			gnutls_free(datum.data);
+			if (result != 0) {
+				gnutls_assert();
+				return result;
+			}
 			return 0;
 		}
 	}

--- a/lib/x509/key_encode.c
+++ b/lib/x509/key_encode.c
@@ -423,8 +423,13 @@ int _gnutls_x509_write_ecc_params(const gnutls_ecc_curve_t curve,
 	der->size = 0;
 
 	oid = gnutls_ecc_curve_get_oid(curve);
-	if (oid == NULL)
+	if (oid == NULL) {
+			// Add debug logging here to see the curve value
+			_gnutls_debug_log("ECC curve value: %d (0x%x), name: %s\n",
+					(int)curve, (unsigned int)curve,
+					gnutls_ecc_curve_get_name(curve) ?: "UNKNOWN");
 		return gnutls_assert_val(GNUTLS_E_INVALID_REQUEST);
+    }
 
 	if ((result = asn1_create_element(_gnutls_get_gnutls_asn(),
 					  "GNUTLS.ECParameters", &spk)) !=

--- a/lib/x509/privkey.c
+++ b/lib/x509/privkey.c
@@ -2418,6 +2418,7 @@ int gnutls_x509_privkey_generate2(gnutls_x509_privkey_t key,
 		key->pk_algorithm = algo;
 
 		gnutls_datum_t p, g, q;
+        gnutls_ecc_curve_t curve;
 
 		q.size = 0;
 
@@ -2457,14 +2458,17 @@ int gnutls_x509_privkey_generate2(gnutls_x509_privkey_t key,
 			}
 		}
 
-		result = cc->generate_backend(&key->pk_ctx, key, algo,
-					      bits_copy, &p, &g, &q);
+		result = cc->generate_backend(&key->pk_ctx, key, algo, bits_copy, &p,
+					      &g, &q, &curve);
 		if (result < 0 && result != GNUTLS_E_ALGO_NOT_SUPPORTED) {
 			gnutls_assert();
 			return result;
 		} else if (result == 0) {
 			cc->privkey_export_ecdh_raw_backend(key->pk_ctx,
 				&key->params.curve, NULL, NULL, NULL, 0);
+            if (algo == GNUTLS_PK_EC) {
+                key->params.curve = curve;
+            }
 			return 0;
 		}
 	}

--- a/lib/x509/x509.c
+++ b/lib/x509/x509.c
@@ -3319,26 +3319,28 @@ int gnutls_x509_crt_get_key_id(gnutls_x509_crt_t crt, unsigned int flags,
 
 	cc = _gnutls_get_crypto_pk(crt->pk_algorithm);
 	if (cc != NULL) {
-		ret = gnutls_pubkey_init(&pubkey);
-		if (ret < 0) {
-			gnutls_assert();
-			return ret;
-		}
-		ret = gnutls_pubkey_import_x509(pubkey, crt, 0);
-		if (ret < 0) {
-			gnutls_pubkey_deinit(pubkey);
-			gnutls_assert();
-			return ret;
-		}
-		cc = _gnutls_get_crypto_pk(pubkey->params.algo);
-		if (cc != NULL) {
-			ret = _gnutls_get_key_id_provider(&pubkey->params,
-				pubkey->pk_ctx, output_data, output_data_size,
-				flags);
-			gnutls_pubkey_deinit(pubkey);
+        if (crt->der.size > 0 || crt->raw_spki.size > 0) {
+            ret = gnutls_pubkey_init(&pubkey);
+            if (ret < 0) {
+                gnutls_assert();
+                return ret;
+            }
+            ret = gnutls_pubkey_import_x509(pubkey, crt, 0);
+            if (ret < 0) {
+                gnutls_pubkey_deinit(pubkey);
+                gnutls_assert();
+                return ret;
+            }
+            cc = _gnutls_get_crypto_pk(pubkey->params.algo);
+            if (cc != NULL) {
+                ret = _gnutls_get_key_id_provider(&pubkey->params,
+                        pubkey->pk_ctx, output_data, output_data_size,
+                        flags);
+                gnutls_pubkey_deinit(pubkey);
 
-			return ret;
-		}
+                return ret;
+            }
+        }
 	}
 
 	/* initializes params */

--- a/lib/x509/x509_write.c
+++ b/lib/x509/x509_write.c
@@ -288,8 +288,13 @@ int gnutls_x509_crt_set_crq(gnutls_x509_crt_t crt, gnutls_x509_crq_t crq)
 	MODIFIED(crt);
 
 	result = gnutls_x509_crq_verify(crq, 0);
-	if (result < 0)
+	if (result < 0) {
+/* WolfSSL provider may generate ECC keys that don't validate with
+     * standard GnuTLS validation but are still cryptographically valid */
+#ifndef GNUTLS_WOLFSSL
 		return gnutls_assert_val(result);
+#endif
+    }
 
 	result = asn1_copy_node(crt->cert, "tbsCertificate.subject", crq->crq,
 				"certificationRequestInfo.subject");


### PR DESCRIPTION
- Added curve parameter when generating the curve to set it internally at library level later (when generating keys via backend);
- Added raw_spki > 0 and der > 0 checks before calling the importing functions
  of the provider;
- Added check in x509_write to skip the verifification of crq if it was
  made using keys generated by the provider. Differences between how
  gnutls and wolfssl behaves when verifying crq, even if it's valid it
  gets marked as not valid (libcups test still passes);
- Various CRQ related fixes;